### PR TITLE
Returning result set in the same dimension no matter how mamy rows ar…

### DIFF
--- a/lib/rserve.js
+++ b/lib/rserve.js
@@ -114,6 +114,9 @@ var parse_SEXP = function(r, i, attr) {
             i += 4;
         }
         a = convertToMatrix(attr, a);
+        if (attr !== null && attr.class !== undefined) {
+          a.class = attr.class;
+        }
         return [a, i];
     }
     if (ra === XT_ARRAY_DOUBLE) {
@@ -135,6 +138,9 @@ var parse_SEXP = function(r, i, attr) {
             i += 16;
         }
         a = convertToMatrix(attr, a);
+        if (attr !== null && attr.class !== undefined) {
+          a.class = attr.class;
+        }
         return [a, i];
     }
     if (ra === XT_ARRAY_STR) {
@@ -148,6 +154,9 @@ var parse_SEXP = function(r, i, attr) {
             i++;
         }
         a = convertToMatrix(attr, a);
+        if (attr !== null && attr.class !== undefined) {
+          a.class = attr.class;
+        }
         return [a, i];
     }
     if (ra === XT_ARRAY_BOOL) {
@@ -162,6 +171,9 @@ var parse_SEXP = function(r, i, attr) {
         }
         if (n === 1) return [a[0], i];
         a = convertToMatrix(attr, a);
+        if (attr !== null && attr.class !== undefined) {
+          a.class = attr.class;
+        }
         return [a, i];
     }
     if (ra === XT_RAW) {

--- a/lib/rserve.js
+++ b/lib/rserve.js
@@ -115,7 +115,6 @@ var parse_SEXP = function(r, i, attr) {
             a.push(h.int32(r, i));
             i += 4;
         }
-        if (a.length === 1) return [a[0], i];
         a = convertToMatrix(attr, a);
         return [a, i];
     }
@@ -125,7 +124,6 @@ var parse_SEXP = function(r, i, attr) {
             a.push(h.flt64(r, i)[0]);
             i += 8;
         }
-        if (a.length === 1) return [a[0], i];
         a = convertToMatrix(attr, a);
         return [a, i];
     }
@@ -135,7 +133,6 @@ var parse_SEXP = function(r, i, attr) {
             a.push([h.flt64(r, i)[0], h.flt64(r, i + 8)[0]]);
             i += 16;
         }
-        if (a.length === 1) return [a[0], i];
         a = convertToMatrix(attr, a);
         return [a, i];
     }
@@ -149,7 +146,6 @@ var parse_SEXP = function(r, i, attr) {
             }
             i++;
         }
-        if (a.length === 1) return [a[0], i];
         a = convertToMatrix(attr, a);
         return [a, i];
     }

--- a/lib/rserve.js
+++ b/lib/rserve.js
@@ -169,7 +169,6 @@ var parse_SEXP = function(r, i, attr) {
             a.push((v === 1) ? true : ((v === 0) ? false : null));
             k++;
         }
-        if (n === 1) return [a[0], i];
         a = convertToMatrix(attr, a);
         if (attr !== null && attr.class !== undefined) {
           a.class = attr.class;

--- a/lib/rserve.js
+++ b/lib/rserve.js
@@ -37,7 +37,7 @@ var XT_NULL = 0,
     XT_HAS_ATTR = 128;
 
 var parse_SEXP = function(r, i, attr) {
-    var oi, ra, rl, eoa, al, a, ret, names, na, k, retval, rettag, n, v;
+    var oi, ra, rl, eoa, al, a, ret, names, k, retval, rettag, n, v;
 
     if(typeof attr === 'undefined') {
         attr = null;
@@ -73,11 +73,9 @@ var parse_SEXP = function(r, i, attr) {
         }
         if (attr !== null && typeof attr.names !== 'undefined') {
             names = attr.names;
-            na = {};
             for (k = 0; k < a.length; k++) {
-                na[names[k]] = a[k];
+                a[names[k]] = a[k];
             }
-            return [na, i];
         }
         return [a, i];
     }

--- a/lib/rserve.js
+++ b/lib/rserve.js
@@ -123,6 +123,9 @@ var parse_SEXP = function(r, i, attr) {
             i += 8;
         }
         a = convertToMatrix(attr, a);
+        if (attr !== null && attr.class !== undefined) {
+          a.class = attr.class;
+        }
         return [a, i];
     }
     if (ra === XT_ARRAY_CPLX) {


### PR DESCRIPTION
Currently, the dimension of the result array is different between when R statement evaluates to 1 row and multiple rows. This is not useful when dealing with the result set programatically. For example, when the client program expects 3 dimension array as output, and one day the data set has updated and the same R statement evaluates to 1 row data set, then the output will be 2 dimension flattened array, and the program will fail to parse.

This pull request will remove the special handling for 1 row data set.

Thanks in advance!
